### PR TITLE
Fix undefined behavior in ConstantsStorage and bias in reservoir sampling

### DIFF
--- a/SudokuPerfTests/Sudoku9PerfTests.swift
+++ b/SudokuPerfTests/Sudoku9PerfTests.swift
@@ -32,8 +32,10 @@ class Sudoku9PerfTests: XCTestCase {
                 board = SudokuBoard.randomFullyFilledBoard(using: rng)
             }
         }
-        XCTAssertEqual(board,
-                       SudokuBoard("725913486981645327634728159849561273276839541513274698397456812158392764462187935"))
+        // The exact board depends on how many random values the solver consumes,
+        // so instead of pinning a specific board, check that generation is
+        // deterministic for a fixed seed.
+        XCTAssertEqual(board, SudokuBoard.randomFullyFilledBoard(using: WyRand(seed: 42)))
         XCTAssertTrue(board.isValid)
         XCTAssertTrue(board.isFullyFilled)
         XCTAssertEqual(board.clues, 81)

--- a/SudokuSolver/Constants.swift
+++ b/SudokuSolver/Constants.swift
@@ -1,20 +1,60 @@
 struct ConstantsStorage<SudokuType: SudokuTypeProtocol> {
-    
-    /// The 39  indicies that need to be checked when changing an index.
-    /// (15 in the same row, 15 in the same column and then 9 remaining in the box)
-    /// Laid out as a countinous array of 349indexes. Use the helper
-    /// method to access the values.
-    private let indiciesAffectedByIndex: [[Int]]
-    private let indiciesInSameRowExclusive: [[Int]]
-    private let indiciesInSameColumnExclusive: [[Int]]
-    private let indiciesInSameBoxExclusive: [[Int]]
-    private let allIndiciesInRow: [[Int]]
-    private let allIndiciesInColumn: [[Int]]
-    private let allIndiciesInBox: [[Int]]
-    
+
+    /// A table of precalculated index rows, where all rows have the same length,
+    /// backed by a single flat buffer that is allocated once and intentionally
+    /// never deallocated.
+    ///
+    /// The solver's hot loops read these tables through `UnsafeBufferPointer`s to
+    /// avoid ARC and bounds-checking overhead. Escaping a pointer out of
+    /// `Array.withUnsafeBufferPointer` (the previous approach) is undefined
+    /// behavior even if the array is kept alive elsewhere, so instead the rows
+    /// are copied into a manually allocated buffer that is never deallocated.
+    /// Reading through pointers into that buffer is well-defined for the
+    /// lifetime of the program.
+    ///
+    /// Since the backing memory is deliberately leaked, values of this type must
+    /// only be stored in variables that live for the whole program, like the
+    /// `constants` static properties on the Sudoku types.
+    private struct ImmortalIndexTable {
+
+        private let base: UnsafePointer<Int>
+        private let rowWidth: Int
+        private let rowCount: Int
+
+        init(_ rows: [[Int]]) {
+            let rowWidth = rows.first?.count ?? 0
+            precondition(rowWidth > 0, "Table must not be empty")
+            precondition(rows.allSatisfy { $0.count == rowWidth },
+                         "All rows in a table must have the same length")
+            let flattened = rows.flatMap { $0 }
+            let storage = UnsafeMutableBufferPointer<Int>.allocate(capacity: flattened.count)
+            _ = storage.initialize(from: flattened)
+            self.base = UnsafePointer(storage.baseAddress!)
+            self.rowWidth = rowWidth
+            self.rowCount = rows.count
+        }
+
+        subscript(row: Int) -> UnsafeBufferPointer<Int> {
+            assert((0..<rowCount).contains(row), "Row \(row) out of bounds")
+            return UnsafeBufferPointer(start: base + row * rowWidth, count: rowWidth)
+        }
+
+    }
+
+    /// The indicies that need to be checked when changing an index:
+    /// the other indicies in the same row, in the same column, and the
+    /// remaining indicies in the same box.
+    private let indiciesAffectedByIndexTable: ImmortalIndexTable
+    private let indiciesInSameRowExclusiveTable: ImmortalIndexTable
+    private let indiciesInSameColumnExclusiveTable: ImmortalIndexTable
+    private let indiciesInSameBoxExclusiveTable: ImmortalIndexTable
+    private let allIndiciesInRowTable: ImmortalIndexTable
+    private let allIndiciesInColumnTable: ImmortalIndexTable
+    private let allIndiciesInBoxTable: ImmortalIndexTable
+
     init() {
-        
-        self.indiciesAffectedByIndex = SudokuType.allCells.map { index in
+
+        self.indiciesAffectedByIndexTable = ImmortalIndexTable(SudokuType.allCells.map { index in
             var indicies = Set<Int>()
             Self._indiciesInSameRowInclusive(as: index).forEach { indicies.insert($0) }
             Self._indiciesInSameColumnInclusive(as: index).forEach { indicies.insert($0) }
@@ -22,44 +62,44 @@ struct ConstantsStorage<SudokuType: SudokuTypeProtocol> {
             //Remove self
             indicies.remove(index)
             return Array(indicies).sorted()
-        }
-    
-        self.indiciesInSameRowExclusive = SudokuType.allCells.map { index1 in
-            Self._indiciesInSameRowInclusive(as: index1).filter { index2 in index1 != index2 }
-        }
-        
-        self.indiciesInSameColumnExclusive = SudokuType.allCells.map { index1 in
-            Self._indiciesInSameColumnInclusive(as: index1).filter { index2 in index1 != index2 }
-        }
-        
-        self.indiciesInSameBoxExclusive = SudokuType.allCells.map { index1 in
-            Self._indiciesInSameBoxInclusive(as: index1).filter { index2 in index1 != index2 }
-        }
-            
-        self.allIndiciesInRow = SudokuType.allPossibilities.map { row in
-            SudokuType.allPossibilities.map { offset in row * SudokuType.possibilities + offset }
-        }
+        })
 
-        self.allIndiciesInColumn = SudokuType.allPossibilities.map { offset in
+        self.indiciesInSameRowExclusiveTable = ImmortalIndexTable(SudokuType.allCells.map { index1 in
+            Self._indiciesInSameRowInclusive(as: index1).filter { index2 in index1 != index2 }
+        })
+
+        self.indiciesInSameColumnExclusiveTable = ImmortalIndexTable(SudokuType.allCells.map { index1 in
+            Self._indiciesInSameColumnInclusive(as: index1).filter { index2 in index1 != index2 }
+        })
+
+        self.indiciesInSameBoxExclusiveTable = ImmortalIndexTable(SudokuType.allCells.map { index1 in
+            Self._indiciesInSameBoxInclusive(as: index1).filter { index2 in index1 != index2 }
+        })
+
+        self.allIndiciesInRowTable = ImmortalIndexTable(SudokuType.allPossibilities.map { row in
+            SudokuType.allPossibilities.map { offset in row * SudokuType.possibilities + offset }
+        })
+
+        self.allIndiciesInColumnTable = ImmortalIndexTable(SudokuType.allPossibilities.map { offset in
             stride(from: 0, to: SudokuType.cells, by: SudokuType.possibilities).map { start in start + offset }
-        }
-           
+        })
+
         let starts = Self.boxOffsets().map { $0 * SudokuType.sideOfBox }
-        self.allIndiciesInBox = starts.map { start in
+        self.allIndiciesInBoxTable = ImmortalIndexTable(starts.map { start in
             Self.boxOffsets().map { offset in start + offset }
-        }
+        })
     }
-    
+
     private static func _indiciesInSameRowInclusive(as index: Int) -> CountableRange<Int> {
         let start = (index / SudokuType.possibilities) * SudokuType.possibilities
         let end = start + SudokuType.possibilities
         return start..<end
     }
-    
+
     private static func _indiciesInSameColumnInclusive(as index: Int) -> StrideTo<Int> {
         stride(from: index % SudokuType.possibilities, to: SudokuType.cells, by: SudokuType.possibilities)
     }
-    
+
     private static func _indiciesInSameBoxInclusive(as index: Int) -> [Int] {
         let row = index / SudokuType.possibilities
         let column = index % SudokuType.possibilities
@@ -68,50 +108,38 @@ struct ConstantsStorage<SudokuType: SudokuTypeProtocol> {
                 + (column / SudokuType.sideOfBox) * SudokuType.sideOfBox
         return Self.boxOffsets().map { startIndexOfBlock + $0 }
     }
-    
+
     private static func boxOffsets() -> [Int] {
         stride(from: 0, to: SudokuType.possibilities * SudokuType.sideOfBox, by: SudokuType.possibilities)
         .flatMap { $0..<($0 + SudokuType.sideOfBox) }
     }
-    
-    // This function escapes pointers to underlying arrays, since that avoids a lot of ARC overhead
-    // We can do this because we know that the whole ConstantsStorage variable is keep alive in a global static variable
-    // and that the underlying arrays don't change, but be very carefull when using this method.
-    private func unsafeExportHelper(_ i: Int, _ array: [[Int]]) -> UnsafeBufferPointer<Int> {
-        assert(array.indices.contains(i))
-        return array.withUnsafeBufferPointer {
-            return $0[i].withUnsafeBufferPointer {
-                return $0
-            }
-        }
-    }
-    
+
     func allIndiciesInRow(_ i: Int) -> UnsafeBufferPointer<Int> {
-        unsafeExportHelper(i, allIndiciesInRow)
+        allIndiciesInRowTable[i]
     }
-    
+
     func allIndiciesInColumn(_ i: Int) -> UnsafeBufferPointer<Int> {
-        unsafeExportHelper(i, allIndiciesInColumn)
+        allIndiciesInColumnTable[i]
     }
-    
+
     func allIndiciesInBox(_ i: Int) -> UnsafeBufferPointer<Int> {
-        unsafeExportHelper(i, allIndiciesInBox)
+        allIndiciesInBoxTable[i]
     }
-    
+
     func indiciesAffectedByIndex(_ i: Int) -> UnsafeBufferPointer<Int> {
-        unsafeExportHelper(i, indiciesAffectedByIndex)
+        indiciesAffectedByIndexTable[i]
     }
-    
+
     func indiciesInSameRowExclusive(_ i: Int) -> UnsafeBufferPointer<Int> {
-        unsafeExportHelper(i, indiciesInSameRowExclusive)
+        indiciesInSameRowExclusiveTable[i]
     }
-    
+
     func indiciesInSameColumnExclusive(_ i: Int) -> UnsafeBufferPointer<Int> {
-        unsafeExportHelper(i, indiciesInSameColumnExclusive)
+        indiciesInSameColumnExclusiveTable[i]
     }
-    
+
     func indiciesInSameBoxExclusive(_ i: Int) -> UnsafeBufferPointer<Int> {
-        unsafeExportHelper(i, indiciesInSameBoxExclusive)
+        indiciesInSameBoxExclusiveTable[i]
     }
-    
+
 }

--- a/SudokuSolver/SudokuTypes.swift
+++ b/SudokuSolver/SudokuTypes.swift
@@ -25,7 +25,7 @@ enum Sudoku4: SudokuTypeProtocol {
     static var allTrueCellStorage: UInt8 = 0b1111
     static var sideOfBox: Int { 2 }
     static var solvedRepresentation = (1...4).map(String.init)
-    static var constants: ConstantsStorage<Self> = ConstantsStorage()
+    static let constants: ConstantsStorage<Self> = ConstantsStorage()
 }
 
 enum Sudoku9: SudokuTypeProtocol {
@@ -34,7 +34,7 @@ enum Sudoku9: SudokuTypeProtocol {
     static var allTrueCellStorage: UInt16 = 0b111111111
     static var sideOfBox: Int { 3 }
     static var solvedRepresentation = (1...9).map(String.init)
-    static var constants: ConstantsStorage<Self> = ConstantsStorage()
+    static let constants: ConstantsStorage<Self> = ConstantsStorage()
 }
 
 enum Sudoku16: SudokuTypeProtocol {
@@ -43,7 +43,7 @@ enum Sudoku16: SudokuTypeProtocol {
     static var allTrueCellStorage: UInt16 = 0b11111111_11111111
     static var sideOfBox: Int { 4 }
     static var solvedRepresentation = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"]
-    static var constants: ConstantsStorage<Self> = ConstantsStorage()
+    static let constants: ConstantsStorage<Self> = ConstantsStorage()
 }
 
 enum Sudoku25: SudokuTypeProtocol {
@@ -52,7 +52,7 @@ enum Sudoku25: SudokuTypeProtocol {
     static var allTrueCellStorage: UInt32 = 0b11111_11111_11111_11111_11111
     static var sideOfBox: Int { 5 }
     static var solvedRepresentation = (65...89).map { String(UnicodeScalar($0)) } // "A"..."Z"
-    static var constants: ConstantsStorage<Self> = ConstantsStorage()
+    static let constants: ConstantsStorage<Self> = ConstantsStorage()
 }
 
 typealias SudokuBoard4 = SudokuBoard<Sudoku4>

--- a/SudokuSolver/Utils.swift
+++ b/SudokuSolver/Utils.swift
@@ -32,9 +32,14 @@ extension Collection {
     func randomElement<R: RNG>(using rng: inout R, where predicate: (Element) -> Bool) -> Element? {
         var result: Element?
         var count = 0
-        for element in self where predicate(element) && Int.random(in: 0...count, using: &rng) == 0 {
-            result = element
+        for element in self where predicate(element) {
+            // Replace the current result with probability 1/count, where count is the
+            // number of matching elements seen so far. This gives every matching
+            // element an equal probability of being the final result.
             count += 1
+            if Int.random(in: 0..<count, using: &rng) == 0 {
+                result = element
+            }
         }
         return result
     }


### PR DESCRIPTION
Fixes the two highest-severity findings from a review of the `SudokuSolver` library code.

## 1. Undefined behavior: pointers escaping `withUnsafeBufferPointer` (`Constants.swift`)

`ConstantsStorage.unsafeExportHelper` returned an `UnsafeBufferPointer` out of nested `Array.withUnsafeBufferPointer` closures. The pointer is only valid for the duration of the closure, so escaping it is undefined behavior — and `$0[i]` additionally produced a temporary COW copy of the inner array, so the escaped pointer's only guaranteed owner died at the end of the expression. It happened to work, but nothing in the language guarantees it keeps working.

The fix keeps the performance-motivated design (handing out raw `UnsafeBufferPointer` rows with no ARC traffic or bounds checks in the hot loops) but makes it well-defined:

- Each index table is flattened into a single `UnsafeMutableBufferPointer<Int>` allocated once in `init` and **intentionally never deallocated** (a new private `ImmortalIndexTable` type). Since `ConstantsStorage` only lives in the `constants` statics on the Sudoku types, the memory would live for the whole program anyway; now the pointer validity argument is real instead of hoped-for.
- Accessor rows are computed as `base + row * rowWidth`, so per-call cost is the same or lower than before (no closure calls, no retain/release).
- The `constants` static properties changed from `var` to `let` — the safety argument requires the storage never be replaced. (This also satisfies the existing `static var constants { get }` protocol requirement.)

All accessor method signatures are unchanged; no call sites in the solver were touched.

## 2. Biased reservoir sampling (`Utils.swift`)

`Collection.randomElement(using:where:)` only incremented `count` when an element was *selected*, but reservoir sampling requires counting every element that *matches the predicate*. The resulting distribution was non-uniform (for three candidates: 1/4, 1/3, 5/12 instead of 1/3 each), biased toward later elements. Since this method is how `unsolvedIndexWithMostConstraints` picks the guess cell, it skewed the distribution of randomly generated boards. Solver *correctness* was never affected — any pick yields valid solutions.

Now each matching element replaces the current pick with probability `1/count`, which is textbook-uniform.

## Test change

The sampling fix changes how many random values are consumed for a given seed, so the board that `WyRand(seed: 42)` produces changes. `Sudoku9PerfTests.testPerfRandomFullyFilledBoard` pinned that exact board; it now asserts that generation is deterministic for a fixed seed (two runs with the same seed produce the same board), which preserves the test's intent without depending on the exact consumption sequence. The functional tests only assert properties (validity, clue counts), so they are unaffected.

## Verification status — please run tests and benchmarks locally

⚠️ This branch was prepared in a Linux environment with **no Swift toolchain available** (swift.org is blocked by the sandbox network policy), so it has **not been compiled or benchmarked**. Before merging, please run locally:

1. The `SudokuTests` suite (correctness).
2. The `SudokuPerfTests` suite against `master` and this branch to compare `measure` baselines.

Expected perf impact: none to slightly positive. The hot-path reads go through the same kind of raw pointer as before but without the two nested closure invocations per lookup; the only added cost is a one-time flatten-and-copy of each table at startup. The reservoir-sampling fix draws the same number of random values per call as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjCqjWBaEmSun1sDR6jRhD

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjCqjWBaEmSun1sDR6jRhD)_